### PR TITLE
Made the NorthwindInitializer thread friendly for unit testing

### DIFF
--- a/Application.Tests/Application.Tests.csproj
+++ b/Application.Tests/Application.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="..\Application\Application.csproj" />
+    <ProjectReference Include="..\Persistance\Persistance.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Application.Tests/Managers/ChangeEmployeeReportToCommandTest.cs
+++ b/Application.Tests/Managers/ChangeEmployeeReportToCommandTest.cs
@@ -1,0 +1,85 @@
+﻿using NorthwindTraders.Application.Managers.Commands;
+using NorthwindTraders.Domain;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Application.Tests.Managers
+{
+    public class ChangeEmployeeReportToCommandTest
+        : TestBase
+    {
+        [Fact]
+        public void ShouldMoveEmployeeUnderManager()
+        {
+            // Prepare
+            var context = InitAndGetDbContext();
+            var command = new ChangeEmployeeReportToCommand(context);
+
+            // Execute
+            int reportTo = 2;
+            command.Execute(new EmployeeUnderManagerModel
+            {
+                EmployeeId = 1,
+                ManagerId = reportTo
+            });
+
+            // Asses
+            Assert.Single(context.Employees
+                .Where(e => e.EmployeeId == 1 && e.ReportsTo == reportTo));
+        }
+
+        [Fact]
+        public void ShouldFailForNonExistingManager()
+        {
+            // Prepare
+            var context = InitAndGetDbContext();
+            var command = new ChangeEmployeeReportToCommand(context);
+
+            // Execute and asses
+            int reportTo = 3;
+            Assert.Throws<ArgumentException>(() => command.Execute(new EmployeeUnderManagerModel
+            {
+                EmployeeId = 1,
+                ManagerId = reportTo
+            }));
+        }
+        
+        [Fact]
+        public void ShouldNotBeManagerOfItself()
+        {
+            // Prepare
+            var context = InitAndGetDbContext();
+            var command = new ChangeEmployeeReportToCommand(context);
+
+            // Execute and asses
+            int reportTo = 1;
+            Assert.Throws<ArgumentException>(() => command.Execute(new EmployeeUnderManagerModel
+            {
+                EmployeeId = 1,
+                ManagerId = reportTo
+            }));
+        }
+
+        private NorthwindTraders.Persistance.NorthwindContext InitAndGetDbContext()
+        {
+            //UseSqlite();
+            var context = GetDbContext();
+
+            context.Employees.Add(new Employee
+            {
+                EmployeeId = 1,
+                FirstName = "",
+                LastName = ""
+            });
+            context.Employees.Add(new Employee
+            {
+                EmployeeId = 2,
+                FirstName = "",
+                LastName = ""
+            });
+            context.SaveChanges();
+            return context;
+        }
+    }
+}

--- a/Application.Tests/Reports/EmployeesWithManagersQueryTests.cs
+++ b/Application.Tests/Reports/EmployeesWithManagersQueryTests.cs
@@ -1,0 +1,28 @@
+﻿using NorthwindTraders.Application.Reports.Queries;
+using NorthwindTraders.Persistance;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Application.Tests.Reports
+{
+    public class EmployeesWithManagersQueryTests : TestBase
+    {
+        [Fact]
+        public async Task ShouldReturnReport()
+        {
+            UseSqlite();
+
+            var context = GetDbContext();
+            NorthwindInitializer.Initialize(context);
+
+            var query = new EmployeesWithManagersQuery(context);
+            var result = await query.Execute();
+
+            Assert.NotEmpty(result);
+            Assert.Equal(8, result.Count());
+            Assert.Contains(result, r => r.ManagerTitle == "Vice President, Sales");
+            Assert.DoesNotContain(result, r => r.EmployeeTitle == "Vice President, Sales");
+        }
+    }
+}

--- a/Application.Tests/Reports/EmployeesWithManagersQueryViewTests.cs
+++ b/Application.Tests/Reports/EmployeesWithManagersQueryViewTests.cs
@@ -1,0 +1,41 @@
+﻿using Dapper;
+using Microsoft.EntityFrameworkCore;
+using NorthwindTraders.Application.Reports.Queries;
+using NorthwindTraders.Persistance;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Application.Tests.Reports
+{
+    public class EmployeesWithManagersQueryViewTests : TestBase
+    {
+        [Fact]
+        public async Task ShouldReturnReport()
+        {
+            UseSqlite();
+
+            var context = GetDbContext();
+            NorthwindInitializer.Initialize(context);
+
+            context.Database.GetDbConnection().Execute(@"
+CREATE VIEW viewEmployeesWithManagers(
+        EmployeeFirstName, EmployeeLastName, EmployeeTitle,
+        ManagerFirstName, ManagetLastName, ManagerTitle)
+AS 
+SELECT e.FirstName as EmployeeFirstName, e.LastName as EmployeeLastName, e.Title as EmployeeTitle,
+        m.FirstName as ManagerFirstName, m.LastName as ManagetLastName, m.Title as ManagerTitle
+FROM employees AS e
+JOIN employees AS m ON e.ReportsTo = m.EmployeeID
+WHERE e.ReportsTo is not null");
+
+            var query = new EmployeesWithManagersViewQuery(context);
+            var result = await query.Execute();
+
+            Assert.NotEmpty(result);
+            Assert.Equal(8, result.Count());
+            Assert.Contains(result, r => r.ManagerTitle == "Vice President, Sales");
+            Assert.DoesNotContain(result, r => r.EmployeeTitle == "Vice President, Sales");
+        }
+    }
+}

--- a/Application.Tests/TestBase.cs
+++ b/Application.Tests/TestBase.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore;
+using NorthwindTraders.Persistance;
+using System;
+
+namespace Application.Tests
+{
+    public class TestBase
+    {
+        private bool useSqlite;
+
+        public NorthwindContext GetDbContext()
+        {
+            var builder = new DbContextOptionsBuilder<NorthwindContext>();
+            if (useSqlite)
+            {
+                // Use Sqlite DB.
+                builder.UseSqlite("DataSource=:memory:", x => { });
+            }
+            else
+            {
+                // Use In-Memory DB.
+                builder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+            }
+
+            var dbContext = new NorthwindContext(builder.Options);
+            if (useSqlite)
+            {
+                // SQLite needs to open connection to the DB.
+                // Not required for in-memory-database and MS SQL.
+                dbContext.Database.OpenConnection();
+            }
+
+            dbContext.Database.EnsureCreated();
+
+            return dbContext;
+        }
+
+        public void UseSqlite()
+        {
+            useSqlite = true;
+        }
+    }
+}

--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="1.50.4" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Persistance\Persistance.csproj" />
   </ItemGroup>
 

--- a/Application/Employees/Commands/ChangeEmployeesManager/ChangeEmployeeManagerModel.cs
+++ b/Application/Employees/Commands/ChangeEmployeesManager/ChangeEmployeeManagerModel.cs
@@ -1,0 +1,9 @@
+﻿namespace NorthwindTraders.Application.Employees.Commands.ChangeEmployeesManager
+{
+    public class ChangeEmployeeManagerModel
+    {
+        public int EmployeeID { get; set; }
+
+        public int ManagerID { get; set; }
+    }
+}

--- a/Application/Employees/Commands/ChangeEmployeesManager/ChangeEmployeesManagerCommand.cs
+++ b/Application/Employees/Commands/ChangeEmployeesManager/ChangeEmployeesManagerCommand.cs
@@ -1,0 +1,20 @@
+﻿using NorthwindTraders.Persistance;
+using System;
+
+namespace NorthwindTraders.Application.Employees.Commands.ChangeEmployeesManager
+{
+    public class ChangeEmployeesManagerCommand : IChangeEmployeesManagerCommand
+    {
+        private readonly NorthwindContext _context;
+
+        public ChangeEmployeesManagerCommand(NorthwindContext context)
+        {
+            _context = context;
+        }
+
+        public void Execute(ChangeEmployeeManagerModel model)
+        {
+            throw new ArgumentException();
+        }
+    }
+}

--- a/Application/Employees/Commands/ChangeEmployeesManager/IChangeEmployeesManagerCommand.cs
+++ b/Application/Employees/Commands/ChangeEmployeesManager/IChangeEmployeesManagerCommand.cs
@@ -1,0 +1,7 @@
+﻿namespace NorthwindTraders.Application.Employees.Commands.ChangeEmployeesManager
+{
+    public interface IChangeEmployeesManagerCommand
+    {
+        void Execute(ChangeEmployeeManagerModel model);
+    }
+}

--- a/Application/Employees/Queries/EmployeesWithManagers/EmployeeManagerModel.cs
+++ b/Application/Employees/Queries/EmployeesWithManagers/EmployeeManagerModel.cs
@@ -1,0 +1,14 @@
+﻿namespace NorthwindTraders.Application.Employees.Queries.EmployeesWithManagers
+{
+    public class EmployeeManagerModel
+    {
+        public string EmployeeId { get; set; }
+        public string EmployeeFirstName { get; set; }
+        public string EmployeeLastName { get; set; }
+        public string ManagerId { get; set; }
+        public string EmployeeTitle { get; set; }
+        public string ManagerFirstName { get; set; }
+        public string ManagerLastName { get; set; }
+        public string ManagerTitle { get; set; }
+    }
+}

--- a/Application/Employees/Queries/EmployeesWithManagers/EmployeesWithManagersQuery.cs
+++ b/Application/Employees/Queries/EmployeesWithManagers/EmployeesWithManagersQuery.cs
@@ -1,0 +1,30 @@
+﻿using Dapper;
+using Microsoft.EntityFrameworkCore;
+using NorthwindTraders.Persistance;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NorthwindTraders.Application.Employees.Queries.EmployeesWithManagers
+{
+    public class EmployeesWithManagersQuery : IEmployeesWithManagersQuery
+    {
+        private readonly NorthwindContext _context;
+
+        public EmployeesWithManagersQuery(NorthwindContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<EmployeeManagerModel>> Execute()
+        {
+            var sql = @"
+SELECT e.EmployeeId as EmployeeId, e.FirstName as EmployeeFirstName, e.LastName as EmployeeLastName, e.Title as EmployeeTitle,
+   m.EmployeeId as ManagerId, m.FirstName as ManagerFirstName, m.LastName as ManagerLastName, m.Title as ManagerTitle
+FROM employees AS e
+JOIN employees AS m ON e.ReportsTo = m.EmployeeID
+WHERE e.ReportsTo is not null";
+
+            return await _context.Database.GetDbConnection().QueryAsync<EmployeeManagerModel>(sql);
+        }
+    }
+}

--- a/Application/Employees/Queries/EmployeesWithManagers/IEmployeesWithManagersQuery.cs
+++ b/Application/Employees/Queries/EmployeesWithManagers/IEmployeesWithManagersQuery.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NorthwindTraders.Application.Employees.Queries.EmployeesWithManagers
+{
+    public interface IEmployeesWithManagersQuery
+    {
+        Task<IEnumerable<EmployeeManagerModel>> Execute();
+    }
+}

--- a/Application/Managers/Commands/ChangeEmployeeReportToCommand.cs
+++ b/Application/Managers/Commands/ChangeEmployeeReportToCommand.cs
@@ -1,0 +1,35 @@
+﻿using NorthwindTraders.Persistance;
+using System;
+using System.Linq;
+
+namespace NorthwindTraders.Application.Managers.Commands
+{
+    public class ChangeEmployeeReportToCommand : IChangeEmployeeReportToCommand
+    {
+        private readonly NorthwindContext _context;
+
+        public ChangeEmployeeReportToCommand(NorthwindContext context)
+        {
+            _context = context;
+        }
+
+        public void Execute(EmployeeUnderManagerModel model)
+        {
+            if (model.ManagerId == model.EmployeeId)
+            {
+                throw new ArgumentException("Employee and manager ID must not be the same", nameof(model));
+            }
+
+            var employee = _context.Employees.FirstOrDefault(e => e.EmployeeId == model.EmployeeId);
+            var managerExists = _context.Employees.Any(e => e.EmployeeId == model.ManagerId);
+            if (employee == null || !managerExists)
+            {
+                throw new ArgumentException("Employee or manager not existing.", nameof(model));
+            }
+
+            employee.ReportsTo = model.ManagerId;
+
+            _context.SaveChanges();
+        }
+    }
+}

--- a/Application/Managers/Commands/EmployeeUnderManagerModel.cs
+++ b/Application/Managers/Commands/EmployeeUnderManagerModel.cs
@@ -1,0 +1,8 @@
+﻿namespace NorthwindTraders.Application.Managers.Commands
+{
+    public class EmployeeUnderManagerModel
+    {
+        public int EmployeeId { get; set; }
+        public int ManagerId { get; set; }
+    }
+}

--- a/Application/Managers/Commands/IChangeEmployeeReportToCommand.cs
+++ b/Application/Managers/Commands/IChangeEmployeeReportToCommand.cs
@@ -1,0 +1,7 @@
+﻿namespace NorthwindTraders.Application.Managers.Commands
+{
+    public interface IChangeEmployeeReportToCommand
+    {
+        void Execute(EmployeeUnderManagerModel model);
+    }
+}

--- a/Application/Reports/Queries/EmployeeManagerModel.cs
+++ b/Application/Reports/Queries/EmployeeManagerModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NorthwindTraders.Application.Reports.Queries
+{
+    public class EmployeeManagerModel
+    {
+        public string EmployeeId { get; set; }
+        public string EmployeeFirstName { get; set; }
+        public string EmployeeLastName { get; set; }
+        public string ManagerId { get; set; }
+        public string EmployeeTitle { get; set; }
+        public string ManagerFirstName { get; set; }
+        public string ManagerLastName { get; set; }
+        public string ManagerTitle { get; set; }
+    }
+}

--- a/Application/Reports/Queries/EmployeesWithManagersQuery.cs
+++ b/Application/Reports/Queries/EmployeesWithManagersQuery.cs
@@ -1,0 +1,31 @@
+﻿using Dapper;
+using Microsoft.EntityFrameworkCore;
+using NorthwindTraders.Persistance;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NorthwindTraders.Application.Reports.Queries
+{
+    public class EmployeesWithManagersQuery : IEmployeesWithManagersQuery
+    {
+        private readonly NorthwindContext _context;
+
+        public EmployeesWithManagersQuery(NorthwindContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<EmployeeManagerModel>> Execute()
+        {
+            var sql = @"
+SELECT e.EmployeeId as EmployeeId, e.FirstName as EmployeeFirstName, e.LastName as EmployeeLastName, e.Title as EmployeeTitle,
+	   m.EmployeeId as ManagerId, m.FirstName as ManagerFirstName, m.LastName as ManagetLastName, m.Title as ManagerTitle
+FROM employees AS e
+JOIN employees AS m ON e.ReportsTo = m.EmployeeID
+WHERE e.ReportsTo is not null";
+
+            return await _context.Database.GetDbConnection()
+                .QueryAsync<EmployeeManagerModel>(sql);
+        }
+    }
+}

--- a/Application/Reports/Queries/EmployeesWithManagersViewQuery.cs
+++ b/Application/Reports/Queries/EmployeesWithManagersViewQuery.cs
@@ -1,0 +1,25 @@
+﻿using Dapper;
+using Microsoft.EntityFrameworkCore;
+using NorthwindTraders.Persistance;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NorthwindTraders.Application.Reports.Queries
+{
+    public class EmployeesWithManagersViewQuery
+    {
+        private readonly NorthwindContext _context;
+
+        public EmployeesWithManagersViewQuery(NorthwindContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<EmployeeManagerModel>> Execute()
+        {
+            var sql = "select * from viewEmployeesWithManagers";
+            return await _context.Database.GetDbConnection()
+                .QueryAsync<EmployeeManagerModel>(sql);
+        }
+    }
+}

--- a/Application/Reports/Queries/IEmployeesWithManagersQuery.cs
+++ b/Application/Reports/Queries/IEmployeesWithManagersQuery.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NorthwindTraders.Application.Reports.Queries
+{
+    public interface IEmployeesWithManagersQuery
+    {
+        Task<IEnumerable<EmployeeManagerModel>> Execute();
+    }
+}

--- a/NorthwindTraders.sln
+++ b/NorthwindTraders.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Persistance", "Persistance\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Presentation", "Presentation\Presentation.csproj", "{1238BA4D-C9BC-4CE5-BCD1-7A958F62102A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application.Tests", "Application.Tests\Application.Tests.csproj", "{679185AF-A1FB-4225-837C-0BF71225D160}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,8 +46,15 @@ Global
 		{1238BA4D-C9BC-4CE5-BCD1-7A958F62102A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1238BA4D-C9BC-4CE5-BCD1-7A958F62102A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1238BA4D-C9BC-4CE5-BCD1-7A958F62102A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{679185AF-A1FB-4225-837C-0BF71225D160}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{679185AF-A1FB-4225-837C-0BF71225D160}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{679185AF-A1FB-4225-837C-0BF71225D160}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{679185AF-A1FB-4225-837C-0BF71225D160}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0D5D0CA3-C6B8-436C-82B0-39820C8A13FA}
 	EndGlobalSection
 EndGlobal

--- a/Persistance/NorthwindInitializer.cs
+++ b/Persistance/NorthwindInitializer.cs
@@ -7,13 +7,19 @@ namespace NorthwindTraders.Persistance
 {
     public class NorthwindInitializer
     {
-        private static readonly Dictionary<int, Employee> Employees = new Dictionary<int, Employee>();
-        private static readonly Dictionary<int, Supplier> Suppliers = new Dictionary<int, Supplier>();
-        private static readonly Dictionary<int, Category> Categories = new Dictionary<int, Category>();
-        private static readonly Dictionary<int, Shipper> Shippers = new Dictionary<int, Shipper>();
-        private static readonly Dictionary<int, Product> Products = new Dictionary<int, Product>();
+        private readonly Dictionary<int, Employee> Employees = new Dictionary<int, Employee>();
+        private readonly Dictionary<int, Supplier> Suppliers = new Dictionary<int, Supplier>();
+        private readonly Dictionary<int, Category> Categories = new Dictionary<int, Category>();
+        private readonly Dictionary<int, Shipper> Shippers = new Dictionary<int, Shipper>();
+        private readonly Dictionary<int, Product> Products = new Dictionary<int, Product>();
 
         public static void Initialize(NorthwindContext context)
+        {
+            var initializer = new NorthwindInitializer();
+            initializer.SeedEverything(context);
+        }
+
+        public void SeedEverything(NorthwindContext context)
         {
             context.Database.EnsureCreated();
 
@@ -41,7 +47,7 @@ namespace NorthwindTraders.Persistance
             SeedOrders(context);
         }
 
-        public static void SeedCustomers(NorthwindContext context)
+        public void SeedCustomers(NorthwindContext context)
         {
             var customers = new[]
             {
@@ -143,7 +149,7 @@ namespace NorthwindTraders.Persistance
             context.SaveChanges();
         }
 
-        private static void SeedRegions(NorthwindContext context)
+        private void SeedRegions(NorthwindContext context)
         {
             var regions = new[]
             {
@@ -158,7 +164,7 @@ namespace NorthwindTraders.Persistance
             context.SaveChanges();
         }
 
-        private static void SeedTerritories(NorthwindContext context)
+        private void SeedTerritories(NorthwindContext context)
         {
             var territories = new[]
             {
@@ -222,7 +228,7 @@ namespace NorthwindTraders.Persistance
             context.SaveChanges();
         }
 
-        private static void SeedEmployees(NorthwindContext context)
+        private void SeedEmployees(NorthwindContext context)
         {
             Employees.Add(2,
                 new Employee
@@ -505,7 +511,7 @@ namespace NorthwindTraders.Persistance
             context.SaveChanges();
         }
 
-        private static void SeedCategories(NorthwindContext context)
+        private void SeedCategories(NorthwindContext context)
         {
             Categories.Add(1, new Category
             {
@@ -571,7 +577,7 @@ namespace NorthwindTraders.Persistance
             context.SaveChanges();
         }
 
-        private static void SeedShippers(NorthwindContext context)
+        private void SeedShippers(NorthwindContext context)
         {
             Shippers.Add(1, new Shipper { CompanyName = "Speedy Express", Phone = "(503) 555-9831" });
             Shippers.Add(2, new Shipper { CompanyName = "United Package", Phone = "(503) 555-3199" });
@@ -585,7 +591,7 @@ namespace NorthwindTraders.Persistance
             context.SaveChanges();
         }
 
-        private static void SeedSuppliers(NorthwindContext context)
+        private void SeedSuppliers(NorthwindContext context)
         {
             Suppliers.Add(1, new Supplier { CompanyName = "Exotic Liquids", ContactName = "Charlotte Cooper", ContactTitle = "Purchasing Manager", Address = "49 Gilbert St.", City = "London", PostalCode = "EC1 4SD", Fax = "", Phone = "(171) 555-2222", HomePage = "" });
             Suppliers.Add(2, new Supplier { CompanyName = "New Orleans Cajun Delights", ContactName = "Shelley Burke", ContactTitle = "Order Administrator", Address = "P.O. Box 78934", City = "New Orleans", Region = "LA", PostalCode = "70117", Fax = "", Phone = "(100) 555-4822", HomePage = "#CAJUN.HTM#" });
@@ -625,7 +631,7 @@ namespace NorthwindTraders.Persistance
             context.SaveChanges();
         }
 
-        private static void SeedProducts(NorthwindContext context)
+        private void SeedProducts(NorthwindContext context)
         {
             Products.Add(1, new Product { ProductName = "Chai", Supplier = Suppliers[1], Category = Categories[1], QuantityPerUnit = "10 boxes x 20 bags", UnitPrice = 18.00m, UnitsInStock = 39, UnitsOnOrder = 0, ReorderLevel = 10, Discontinued = false });
             Products.Add(2, new Product { ProductName = "Chang", Supplier = Suppliers[1], Category = Categories[1], QuantityPerUnit = "24 - 12 oz bottles", UnitPrice = 19.00m, UnitsInStock = 17, UnitsOnOrder = 40, ReorderLevel = 25, Discontinued = false });
@@ -713,7 +719,7 @@ namespace NorthwindTraders.Persistance
             context.SaveChanges();
         }
 
-        private static void SeedOrders(NorthwindContext context)
+        private void SeedOrders(NorthwindContext context)
         {
             var orders = new List<Order>();
 

--- a/Presentation/Controllers/AdminController.cs
+++ b/Presentation/Controllers/AdminController.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using NorthwindTraders.Application.Employees.Commands.ChangeEmployeesManager;
+using NorthwindTraders.Application.Employees.Queries.EmployeesWithManagers;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NorthwindTraders.Controllers
+{
+    [Produces("application/json")]
+    [Route("api/[controller]/[action]")]
+    public class AdminController
+    {
+        [HttpPost]
+        public void ChangeEmployeeManager(
+            [FromServices] IChangeEmployeesManagerCommand command,
+            [FromBody] ChangeEmployeeManagerModel model)
+        {
+            command.Execute(model);
+        }
+
+        [HttpGet]
+        public async Task<IEnumerable<EmployeeManagerModel>> EmployeeManagerReport(
+            [FromServices] IEmployeesWithManagersQuery query
+            )
+        {
+            return await query.Execute();
+        }
+    }
+}

--- a/Presentation/Infrastructure/AutofacModule.cs
+++ b/Presentation/Infrastructure/AutofacModule.cs
@@ -1,8 +1,4 @@
 ﻿using Autofac;
-using NorthwindTraders.Application.Customers.Commands.CreateCustomer;
-using NorthwindTraders.Application.Customers.Commands.DeleteCustomer;
-using NorthwindTraders.Application.Customers.Commands.UpdateCustomer;
-using NorthwindTraders.Application.Customers.Queries.GetCustomerDetail;
 using NorthwindTraders.Application.Customers.Queries.GetCustomersList;
 using NorthwindTraders.Common.Dates;
 
@@ -12,11 +8,9 @@ namespace NorthwindTraders.Infrastructure
     {
         protected override void Load(ContainerBuilder builder)
         {
-            builder.RegisterType<GetCustomersListQuery>().As<IGetCustomersListQuery>();
-            builder.RegisterType<GetCustomerDetailQuery>().As<IGetCustomerDetailQuery>();
-            builder.RegisterType<CreateCustomerCommand>().As<ICreateCustomerCommand>();
-            builder.RegisterType<UpdateCustomerCommand>().As<IUpdateCustomerCommand>();
-            builder.RegisterType<DeleteCustomerCommand>().As<IDeleteCustomerCommand>();
+            builder.RegisterAssemblyTypes(typeof(GetCustomersListQuery).Assembly)
+                .Where(x => x.Name.EndsWith("Command") || x.Name.EndsWith("Query") || x.Name.EndsWith("Service"))
+                .AsImplementedInterfaces();
             builder.RegisterType<MachineDateTime>().As<IDateTime>();
         }
     }

--- a/Presentation/Presentation.csproj
+++ b/Presentation/Presentation.csproj
@@ -14,6 +14,7 @@
 		<PackageReference Include="Autofac" Version="4.8.1" />
 		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.1.0-preview1-final" />
+		<PackageReference Include="NSwag.AspNetCore" Version="11.17.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />

--- a/Presentation/Properties/launchSettings.json
+++ b/Presentation/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
@@ -11,7 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/customers",
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Presentation/Startup.cs
+++ b/Presentation/Startup.cs
@@ -5,8 +5,11 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NJsonSchema;
 using NorthwindTraders.Infrastructure;
 using NorthwindTraders.Persistance;
+using NSwag.AspNetCore;
+using System.Reflection;
 
 namespace NorthwindTraders
 {
@@ -25,6 +28,7 @@ namespace NorthwindTraders
             // Add framework services.
             services.AddDbContext<NorthwindContext>(options => options.UseSqlServer(Configuration.GetConnectionString("NorthwindDatabase")));
 
+            services.AddSwagger();
             services.AddMvc();
         }
 
@@ -39,8 +43,14 @@ namespace NorthwindTraders
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
-            app.UseMvc();
 
+            app.UseSwaggerUi3(typeof(Startup).GetTypeInfo().Assembly, s =>
+            {
+                s.GeneratorSettings.DefaultUrlTemplate = "{controller}/{action}/{id?}";
+                s.GeneratorSettings.DefaultPropertyNameHandling = PropertyNameHandling.CamelCase;
+            });
+
+            app.UseMvc();
             NorthwindInitializer.Initialize(context);
         }
     }


### PR DESCRIPTION
Hi Jason,

Another PR. This one addresses the issue when unit tests are running parallel and they are trying to use `NorthwindInitializer`. I removed all of the `static` parts but still kept the same style of initialization.

``` CSharp
NorthwindInitializer.Initialize(context);
```

Behind the scenes, it creates a new instance of `NorthwindInitializer` and seeds the data from that local instance. This allows me to run unit tests in parallel. :)

I hope this small tweak might help you out in the future.