### PR TITLE
convert all projects except ui to Netstandard 2.0

### DIFF
--- a/Northwind.Application/Northwind.Application.csproj
+++ b/Northwind.Application/Northwind.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!--<Import Project="..\Northwind.CodeAnalysis.targets" />-->
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Northwind.Application</AssemblyName>
     <RootNamespace>Northwind.Application</RootNamespace>
   </PropertyGroup>

--- a/Northwind.Common/Northwind.Common.csproj
+++ b/Northwind.Common/Northwind.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!--<Import Project="..\Northwind.CodeAnalysis.targets" />-->
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Northwind.Common</AssemblyName>
     <RootNamespace>Northwind.Common</RootNamespace>
   </PropertyGroup>

--- a/Northwind.Domain/Northwind.Domain.csproj
+++ b/Northwind.Domain/Northwind.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!--<Import Project="..\Northwind.CodeAnalysis.targets" />-->
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Northwind.Domain</AssemblyName>
     <RootNamespace>Northwind.Domain</RootNamespace>
   </PropertyGroup>

--- a/Northwind.Infrastructure/Northwind.Infrastructure.csproj
+++ b/Northwind.Infrastructure/Northwind.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!--<Import Project="..\Northwind.CodeAnalysis.targets" />-->
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Northwind.Persistence/Northwind.Persistence.csproj
+++ b/Northwind.Persistence/Northwind.Persistence.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <LangVersion>7.1</LangVersion>


### PR DESCRIPTION
As the project is about architecture, I might suggest to convert all projects except UI and Tests to netstandard 2.0 to make them reusable on all compatible platforms.