### PR TITLE
Fix request logger triggered twice for each request

### DIFF
--- a/Northwind.WebUI/Startup.cs
+++ b/Northwind.WebUI/Startup.cs
@@ -43,10 +43,9 @@ namespace Northwind.WebUI
             services.AddTransient<IDateTime, MachineDateTime>();
 
             // Add MediatR
-            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestPreProcessorBehavior<,>));
+            services.AddMediatR(typeof(GetProductQueryHandler).GetTypeInfo().Assembly);
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestPerformanceBehaviour<,>));
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestValidationBehavior<,>));
-            services.AddMediatR(typeof(GetProductQueryHandler).GetTypeInfo().Assembly);
 
             // Add DbContext using SQL Server Provider
             services.AddDbContext<NorthwindDbContext>(options =>


### PR DESCRIPTION
The pre/post processor behaviors are automatically
registered in MediatR 6.0. So remove the
RequestPreProcessorBehavior registration and make
sure other pipeline registration after MediatrR service added.

https://github.com/jbogard/MediatR/issues/346