### PR TITLE
fix for update product command return value

### DIFF
--- a/Northwind.Application/Products/Commands/UpdateProduct/UpdateProductCommand.cs
+++ b/Northwind.Application/Products/Commands/UpdateProduct/UpdateProductCommand.cs
@@ -2,7 +2,7 @@
 
 namespace Northwind.Application.Products.Commands.UpdateProduct
 {
-    public class UpdateProductCommand : IRequest
+    public class UpdateProductCommand : IRequest<Unit>
     {
         public int ProductId { get; set; }
 


### PR DESCRIPTION
The **UpdateProductCommandHandler** returns a Unit. In my code the **IRequest** need to specify this return value.